### PR TITLE
fix : 모든 예외를 403 Forbidden 으로 처리하는 에러 수정

### DIFF
--- a/src/main/java/com/fiveman/newsfeed/common/config/SecurityConfig.java
+++ b/src/main/java/com/fiveman/newsfeed/common/config/SecurityConfig.java
@@ -27,7 +27,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/users/signup",
                                 "/api/login",
                                 "/swagger-ui/**",
-                                "/v3/api-docs/**").permitAll() // 인증 없이 허용
+                                "/v3/api-docs/**",
+                                "/error").permitAll() // 인증 없이 허용
                         .anyRequest().authenticated() // 나머지 요청은 인증 필요
                 )
                 .addFilterBefore(new JwtTokenFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class); // JWT 필터 추가


### PR DESCRIPTION
스프링부트에서는 에러가 발생하면 /error라는 URI로 매핑을 시도하는데
SpringSecurity 에서 인증없이 /error 로 매핑하는것을 허용하지 않기때문에 모두 403으로 처리하는 문제가 있었습니다
이를 인증없이 허용하는 경로에 "/error"를 추가하여 버그를 고쳤습니다